### PR TITLE
Fix incorrect "kill" logic in copy propagation

### DIFF
--- a/copyprop.h
+++ b/copyprop.h
@@ -1,6 +1,9 @@
 #pragma once
 #include "common.h"
 #include "set.h"
+#include <ext/hash_map>
+
+using namespace __gnu_cxx;
 
 /*
 	复写传播数据流分析框架
@@ -13,6 +16,18 @@ class CopyPropagation
 	vector<InterInst*>copyExpr;//复写表达式列表
 	Set U;//全集
 	Set E;//空集
+
+	// 定义哈希函数
+    struct var_pointer_hash{
+        size_t operator()(const Var *ptr) const{
+            return reinterpret_cast<size_t>(ptr);
+        }
+    };
+
+    vector<int> uf;// 并查集,用来判断两个变量是否是等价的比如b=a;c=b;那么a,b和c就是等价的
+    hash_map<Var *, int, var_pointer_hash> varToIndex;// 将每个变量映射到一个数字
+    int findParent(int x);// 找出该变量所属的联通分量
+
 	bool translate(Block*block);//复写传播传递函数
 	void analyse();//复写传播数据流分析
 	Var* __find(Set& in,Var*var,Var*src);//递归检测var赋值的源头的内部实现


### PR DESCRIPTION
```
int add(int n)
{
    int a, b;
    b = n;
    a = b;
    n = 3;
    return a;
}
```
考虑上面的代码如果在对`n = 3`进行复写传播时只是简单的只将`b = n`杀死的话那么在对`return a`进行覆写传播时就会复用本应该被杀死的语句`a = b`(先前已被复写传播简化为a = n)导致`return a`中的a会被替换为字面量3这明显是错误的，所以我们在这里保守的杀死一个联通分量中的所有语句。
______
修改前产生的中间代码(错误的):
```
-------------<add>Start--------------
entry
return 3 goto .L1
.L1:
exit
--------------<add>End---------------
编译完成：错误=0,警告=0.
```
______
修改后产生的中间代码:
```
-------------<add>Start--------------
entry
dec a
a = n
return a goto .L1
.L1:
exit
--------------<add>End---------------
编译完成：错误=0,警告=0.
```